### PR TITLE
fix: modify compressed.size output to mimic uncompressed.size

### DIFF
--- a/batbot/spectrogram/__init__.py
+++ b/batbot/spectrogram/__init__.py
@@ -1668,12 +1668,10 @@ def compute_wrapper(
         'segments': metas,
     }
     if 'stft_db' in segments:
-        metadata['size']['compressed'] = (
-            {
-                'width.px': segments['stft_db'].shape[1],
-                'height.px': segments['stft_db'].shape[0],
-            },
-        )
+        metadata['size']['compressed'] = {
+            'width.px': segments['stft_db'].shape[1],
+            'height.px': segments['stft_db'].shape[0],
+        }
 
     metadata_path = join(output_folder, f'{base}.metadata.json')
     with open(metadata_path, 'w') as metafile:


### PR DESCRIPTION
resolves #5 

Modifies the output for the compressed.size to match up with the uncompressed.size without being inside of a tuple.