### PR TITLE
fix: add scipy as explicit runtime dependency

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -11,6 +11,7 @@ pooch
 pyastar2d @ git+https://github.com/bluemellophone/batbot-pyastar2d@master
 rich
 scikit-image
+scipy
 shapely
 sphinx-click
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     pyastar2d @ git+https://github.com/bluemellophone/batbot-pyastar2d@master
     rich
     scikit-image
+    scipy
     shapely
     sphinx-click
     tqdm


### PR DESCRIPTION
## Summary
- Add `scipy` to `requirements/runtime.txt` and `setup.cfg` `install_requires`
- `batbot/spectrogram/__init__.py` imports directly from `scipy.stats` (`median_abs_deviation`, `skew`, `norm`) but `scipy` was not listed as an explicit dependency
- Previously only available transitively through `librosa` and `scikit-image`, which is fragile and could break if those packages change their dependency trees

## Test plan
- [ ] Verify `pip install .` in a clean virtual environment pulls in `scipy`
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)