### PR TITLE
fix: gate LineProfiler behind BATBOT_PROFILE env var

### DIFF
--- a/batbot/spectrogram/__init__.py
+++ b/batbot/spectrogram/__init__.py
@@ -16,7 +16,6 @@ import numpy as np
 import pyastar2d
 import scipy.signal  # Ensure this is at the top with other imports
 import tqdm
-from line_profiler import LineProfiler
 from scipy import ndimage
 
 # from PIL import Image
@@ -29,7 +28,12 @@ from skimage import draw, measure
 
 from batbot import log
 
-lp = LineProfiler()
+PROFILE = os.environ.get('BATBOT_PROFILE', '').lower() in ('1', 'true', 'yes')
+
+if PROFILE:
+    from line_profiler import LineProfiler
+
+    lp = LineProfiler()
 
 
 FREQ_MIN = 5e3
@@ -38,7 +42,8 @@ FREQ_MAX = 120e3
 
 def compute(*args, **kwargs):
     retval = compute_wrapper(*args, **kwargs)
-    lp.print_stats()
+    if PROFILE:
+        lp.print_stats()
     return retval
 
 
@@ -1298,7 +1303,7 @@ def calculate_harmonic_and_echo_flags(
     return harmonic_flag, harmonic_peak, echo_flag, echo_peak
 
 
-@lp
+@lp if PROFILE else lambda f: f
 def compute_wrapper(
     wav_filepath, annotations=None, output_folder='.', bitdepth=16, debug=False, **kwargs
 ):

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -5,6 +5,7 @@ flake8
 # gradio
 ipython
 isort
+line_profiler
 # onnx
 # onnxruntime
 pre-commit

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,7 +2,6 @@ click
 cryptography
 cython
 librosa
-line_profiler
 matplotlib
 numpy
 opencv-python-headless

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
     cryptography
     cython
     librosa
-    line_profiler
     matplotlib
     numpy
     opencv-python-headless


### PR DESCRIPTION
## Summary
- Gate the `LineProfiler` decorator on `compute_wrapper()` behind the `BATBOT_PROFILE` environment variable (`1`, `true`, or `yes` to enable)
- Previously, profiling overhead was incurred on every call unconditionally
- Move `line_profiler` from runtime to optional dependencies since it is only needed during development

## Test plan
- [ ] Run `batbot pipeline` normally — verify no `line_profiler` import or profiling output
- [ ] Run with `BATBOT_PROFILE=1 batbot pipeline` — verify profiling stats are printed
- [ ] Verify `pip install .` no longer pulls in `line_profiler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)