### PR TITLE
chore: align line-length to 100 across Black, isort, and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 extend-ignore = E203,E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ exclude = .git
 
 [tool:isort]
 profile = black
-line_length = 90
+line_length = 100
 multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0


### PR DESCRIPTION
## Summary
- Standardize line-length to 100 across all formatting/linting tools
- Previously Black used 100, isort used 90, and flake8 used 88
- This inconsistency could cause flake8 to flag lines that Black considers valid

### Changes
| Tool | Before | After |
|------|--------|-------|
| Black (`.pre-commit-config.yaml`) | 100 | 100 (unchanged) |
| isort (`setup.cfg`) | 90 | 100 |
| flake8 (`.flake8`) | 88 | 100 |

## Test plan
- [ ] Run `pre-commit run --all-files` and verify no new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)