### PR TITLE
ci: add Python 3.9-3.12 version matrix to CI

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies, run tests and lint with multiple versions of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Testing
@@ -11,8 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use the same Python version used the Dockerfile
-        python-version: [3.12]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       OS: ubuntu-latest


### PR DESCRIPTION
## Summary
- Expand CI test matrix from Python 3.12 only to 3.9, 3.10, 3.11, and 3.12
- `setup.cfg` declares `python_requires = >=3.7` but CI was only testing a single version, leaving compatibility regressions undetected

## Test plan
- [ ] Verify all four matrix jobs run successfully in GitHub Actions
- [ ] Check that test results and coverage are reported for each Python version

🤖 Generated with [Claude Code](https://claude.com/claude-code)