### PR TITLE
fix: add missing scipy.stats import in spectrogram module

### DIFF
--- a/batbot/spectrogram/__init__.py
+++ b/batbot/spectrogram/__init__.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pyastar2d
 import scipy.signal  # Ensure this is at the top with other imports
+import scipy.stats
 import tqdm
 from line_profiler import LineProfiler
 from scipy import ndimage


### PR DESCRIPTION
## Summary
- Add `import scipy.stats` to `batbot/spectrogram/__init__.py`
- The module uses `scipy.stats.median_abs_deviation`, `scipy.stats.skew`, and `scipy.stats.norm` across ~9 call sites but never imports the submodule
- Python does not auto-import submodules, so every call raises `AttributeError: module 'scipy' has no attribute 'stats'`

## Test plan
- [ ] Run `pytest` and verify spectrogram tests pass without `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)