### PR TITLE
fix: correct pooch download URL for example WAV file

### DIFF
--- a/batbot/__init__.py
+++ b/batbot/__init__.py
@@ -157,7 +157,7 @@ def example():
 
     if not exists(wav_filepath):
         wav_filepath = pooch.retrieve(
-            url=f'https://github.com/Kitware/batbot/{TEST_WAV}',
+            url=f'https://raw.githubusercontent.com/Kitware/batbot/main/examples/{TEST_WAV}',
             known_hash=TEST_WAV_HASH,
             progressbar=True,
         )


### PR DESCRIPTION
## Summary
- Fix the pooch download URL in `batbot.example()` from `https://github.com/Kitware/batbot/example1.wav` to `https://raw.githubusercontent.com/Kitware/batbot/main/examples/example1.wav`
- The previous URL is not a valid raw file download URL — GitHub does not serve file content at repository root URLs
- The fallback download path (when the local file doesn't exist) would always fail

## Test plan
- [ ] Remove local `examples/example1.wav` and run `batbot.example()` — verify it downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)