### PR TITLE
fix: use venv python directly in Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN /venv/bin/pip install --no-cache-dir -r requirements/runtime.txt \
  #       /venv/bin/pip install --no-cache-dir onnxruntime-gpu \
  #       ; fi
 
-CMD [".", "/venv/bin/activate", "&&", "exec", "python", "app.py"]
+CMD ["/venv/bin/python", "app.py"]


### PR DESCRIPTION
## Summary
- Replace `CMD [".", "/venv/bin/activate", "&&", "exec", "python", "app.py"]` with `CMD ["/venv/bin/python", "app.py"]`
- JSON exec form does not invoke a shell, so `.` (source), `&&`, and `exec` are passed as literal arguments — the container fails to start
- Since packages are installed into `/venv`, invoking `/venv/bin/python` directly is sufficient and avoids needing to activate the venv

## Test plan
- [ ] Build the Docker image and verify the container starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)