### PR TITLE
fix: correct CI pre-commit invocation and coverage upload path

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Check with pre-commit
         run: |
-          SKIP=hadolint pre-commit
           SKIP=hadolint pre-commit run --all-files
 
       - name: Run tests and coverage
@@ -52,6 +51,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.BATBOT_CODECOV_TOKEN }}
-          files: ./coverage/coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary
Two fixes in the testing workflow:

- **Remove bare `pre-commit` call** (line 42) — Running `pre-commit` without a subcommand just prints help text and exits 0. Only `pre-commit run --all-files` is needed.
- **Fix Codecov upload path** — Changed `./coverage/coverage.xml` to `./coverage.xml`. `pytest-cov` with `--cov-report=xml` writes to the working directory by default, not a `coverage/` subdirectory. Coverage was never actually being uploaded.

## Test plan
- [ ] Verify pre-commit step runs without the redundant invocation
- [ ] Verify Codecov receives coverage data after a successful test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)