### PR TITLE
fix: correct requirements path in ReadTheDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,6 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: requirements.txt
+   - requirements: requirements/runtime.txt
    - method: pip
      path: .


### PR DESCRIPTION
## Summary
- Fix `.readthedocs.yaml` to reference `requirements/runtime.txt` instead of `requirements.txt`
- `requirements.txt` does not exist in the repo root — requirements are split into `requirements/runtime.txt` and `requirements/optional.txt`
- ReadTheDocs builds would fail during dependency installation

## Test plan
- [ ] Trigger a ReadTheDocs build and verify it installs dependencies successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)