### PR TITLE
fix: exit with error code when CLI filepath does not exist

### DIFF
--- a/batbot/batbot.py
+++ b/batbot/batbot.py
@@ -13,8 +13,7 @@ from batbot import log
 
 def pipeline_filepath_validator(ctx, param, value):
     if not exists(value):
-        log.error(f'Input filepath does not exist: {value}')
-        ctx.exit()
+        raise click.BadParameter(f'Input filepath does not exist: {value}')
     return value
 
 


### PR DESCRIPTION
## Summary
- Replace `ctx.exit()` with `raise click.BadParameter(...)` in `pipeline_filepath_validator`
- Previously, passing a non-existent file to `batbot pipeline` would silently exit with code 0 (success), making it impossible for scripts or CI to detect the failure
- `click.BadParameter` prints a proper error message with usage hints and exits with a non-zero status

## Test plan
- [ ] Run `batbot pipeline nonexistent.wav` and verify it exits with a non-zero code and a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)