### PR TITLE
chore: remove unused runtime deps and fix project URLs

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,16 +1,11 @@
 click
-cryptography
-cython
 librosa
-line_profiler
 matplotlib
 numpy
 opencv-python-headless
-Pillow
 pooch
 pyastar2d @ git+https://github.com/bluemellophone/batbot-pyastar2d@master
 rich
 scikit-image
 shapely
-sphinx-click
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,14 +4,14 @@ description = Machine Learning app for the Kitware BatAI Project
 version = attr: batbot.VERSION
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-url = https://github.com/Kitware
+url = https://github.com/Kitware/batbot
 author = Kitware
 author_email = vision@kitware.com
 license = MIT
 license_file = LICENSE
 project_urls =
     Documentation = https://batbot.readthedocs.io
-    Source = https://github.com/Kitware
+    Source = https://github.com/Kitware/batbot
 
 [options]
 packages = find:
@@ -19,20 +19,15 @@ platforms = any
 include_package_data = true
 install_requires =
     click
-    cryptography
-    cython
     librosa
-    line_profiler
     matplotlib
     numpy
     opencv-python-headless
-    Pillow
     pooch
     pyastar2d @ git+https://github.com/bluemellophone/batbot-pyastar2d@master
     rich
     scikit-image
     shapely
-    sphinx-click
     tqdm
 python_requires = >=3.7
 


### PR DESCRIPTION
## Summary
Remove dependencies from `install_requires` and `requirements/runtime.txt` that are unused or dev-only:

| Dependency | Reason for removal |
|---|---|
| `cryptography` | Never imported anywhere in the codebase |
| `cython` | No `.pyx` files exist; build-time dependency at best |
| `Pillow` | `from PIL import Image` is commented out in spectrogram module |
| `sphinx-click` | Sphinx documentation extension, not needed at runtime |
| `line_profiler` | Profiling tool, not needed at runtime |

Also fix truncated project URLs in `setup.cfg` metadata — `https://github.com/Kitware` should be `https://github.com/Kitware/batbot`.

## Test plan
- [ ] Run `pip install .` in a clean venv and verify the package installs without the removed deps
- [ ] Run `pytest` to confirm no import errors from the removed packages
- [ ] Verify PyPI metadata URLs point to the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)